### PR TITLE
Fix Steam API request error log

### DIFF
--- a/aw_watcher_steam/main.py
+++ b/aw_watcher_steam/main.py
@@ -31,7 +31,7 @@ def get_currently_played_games(api_key, steam_id) -> dict:
             data["currently-playing-game"] = response_data["gameextrainfo"]
             data["game-id"] = response_data["gameid"]
         return data
-    raise Exception("Steam API request error, error code:" + response.status_code + " " + response.text)
+    raise Exception("Steam API request error, error code:" + str(response.status_code) + " " + response.text)
 
 def main(): 
     logger = logging.getLogger("aw-watcher-steam")


### PR DESCRIPTION
at line 34 we're trying to concatenate int to str which is imposiible

```python
Error fetching datacan only concatenate str (not "int") to str
Traceback (most recent call last):
  File "/Users/crd5/Projects/aw-watcher-steam/.venv/lib/python3.13/site-packages/aw_watcher_steam/main.py", line 53, in main
    game_data = get_currently_played_games(api_key=api_key,steam_id=steam_id)
  File "/Users/crd5/Projects/aw-watcher-steam/.venv/lib/python3.13/site-packages/aw_watcher_steam/main.py", line 34, in get_currently_played_games
    raise Exception("Steam API request error, error code:" + response.status_code + " " + response.text)
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
TypeError: can only concatenate str (not "int") to str
```